### PR TITLE
fix: nullSpinner missing warn/info methods in MCP server

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -31,6 +31,8 @@ const nullSpinner = {
   stop() { return this; },
   succeed(msg) { return this; },
   fail(msg) { return this; },
+  warn(msg) { return this; },
+  info(msg) { return this; },
 };
 
 /**


### PR DESCRIPTION
Extraction on sites that trigger navigation retries or empty-page retries would crash immediately with 'warn is not a function' because the stub spinner used in MCP context only implemented start/stop/ succeed/fail.