### PR TITLE
feat: support BROWSER_CDP_ENDPOINT for CDP browser connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,10 +93,12 @@ program
         if (opts.noSandbox && opts.browser === 'chromium') {
           launchArgs.push("--no-sandbox", "--disable-setuid-sandbox");
         }
-        browser = await browserType.launch({
-          headless: !useHeaded,
-          args: launchArgs,
-        });
+        browser = process.env.BROWSER_CDP_ENDPOINT
+          ? await chromium.connectOverCDP(process.env.BROWSER_CDP_ENDPOINT)
+          : await browserType.launch({
+              headless: !useHeaded,
+              args: launchArgs,
+            });
 
         try {
           const isMultiPage = opts.pages || opts.sitemap;

--- a/index.js
+++ b/index.js
@@ -93,12 +93,18 @@ program
         if (opts.noSandbox && opts.browser === 'chromium') {
           launchArgs.push("--no-sandbox", "--disable-setuid-sandbox");
         }
-        browser = process.env.BROWSER_CDP_ENDPOINT
-          ? await chromium.connectOverCDP(process.env.BROWSER_CDP_ENDPOINT)
-          : await browserType.launch({
-              headless: !useHeaded,
-              args: launchArgs,
-            });
+        if (process.env.BROWSER_CDP_ENDPOINT) {
+          if (opts.browser !== "chromium") {
+            throw new Error("BROWSER_CDP_ENDPOINT is only supported with --browser chromium.");
+          }
+          spinner.text = "Connecting over CDP...";
+          browser = await browserType.connectOverCDP(process.env.BROWSER_CDP_ENDPOINT);
+        } else {
+          browser = await browserType.launch({
+            headless: !useHeaded,
+            args: launchArgs,
+          });
+        }
 
         try {
           const isMultiPage = opts.pages || opts.sitemap;
@@ -172,7 +178,7 @@ program
           await browser.close();
           browser = null;
 
-          if (useHeaded) throw err;
+          if (useHeaded || process.env.BROWSER_CDP_ENDPOINT) throw err;
 
           if (
             err.message.includes("Timeout") ||


### PR DESCRIPTION
## Summary

Add native support for the `BROWSER_CDP_ENDPOINT` environment variable, allowing dembrandt to connect to an existing browser instance via Chrome DevTools Protocol instead of launching a new one.

## Motivation

When running dembrandt inside a container alongside a shared browser service (e.g. a headless Chromium sidecar), launching a new browser per invocation is wasteful. CDP connection reuse is more efficient and enables tighter integration with browser-as-a-service setups.

## Changes

- `index.js`: when `BROWSER_CDP_ENDPOINT` is set, use `chromium.connectOverCDP()` instead of `browserType.launch()`

## Behavior

| `BROWSER_CDP_ENDPOINT` | Behavior |
|---|---|
| not set | unchanged — launches a new browser as before |
| set (e.g. `http://localhost:9222`) | connects to existing browser via CDP |

## Testing

```bash
# existing behavior unchanged
dembrandt https://example.com

# CDP mode
BROWSER_CDP_ENDPOINT=http://localhost:9222 dembrandt https://example.com